### PR TITLE
Route NuGet restores through CFS

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="upstream-public" value="https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/nuget/v3/index.json" protocolVersion="3" />
+  </packageSources>
+  <packageSourceMapping>
+    <packageSource key="upstream-public">
+      <package pattern="*" />
+    </packageSource>
+  </packageSourceMapping>
+</configuration>

--- a/build.ps1
+++ b/build.ps1
@@ -18,6 +18,30 @@ param(
 Import-Module "$PSScriptRoot\pipelineUtilities.psm1" -Force
 
 $SrcDirectory = "$PSScriptRoot\src"
+$SolutionPath = Join-Path $SrcDirectory "azure-functions-powershell-opentelemetry.sln"
+$NuGetConfigPath = Join-Path $PSScriptRoot "NuGet.config"
+
+function Invoke-Dotnet
+{
+    param(
+        [Parameter(Mandatory=$true)]
+        [string[]]
+        $Arguments
+    )
+
+    & dotnet @Arguments
+    if ($LASTEXITCODE -ne 0)
+    {
+        throw "dotnet $($Arguments -join ' ') failed."
+    }
+}
+
+if (!$NoBuild.IsPresent -or $Test.IsPresent)
+{
+    Write-Log "Restoring solution from the configured package source..."
+    $restoreArguments = @("restore", $SolutionPath, "--configfile", $NuGetConfigPath)
+    Invoke-Dotnet -Arguments $restoreArguments
+}
 
 if (!$NoBuild.IsPresent) {
 
@@ -63,7 +87,8 @@ if (!$NoBuild.IsPresent) {
         Push-Location $project.Value
         try
         {
-            dotnet publish -f $netCoreTFM -c $Configuration
+            $publishArguments = @("publish", "--framework", $netCoreTFM, "--configuration", $Configuration, "--no-restore")
+            Invoke-Dotnet -Arguments $publishArguments
         }
         finally
         {
@@ -93,8 +118,7 @@ if (!$NoBuild.IsPresent) {
 }
 #region Test ==================================================================================
 if ($Test.IsPresent) {
-    Set-Location $SrcDirectory
-    dotnet test
-    if ($LASTEXITCODE -ne 0) { throw "xunit tests failed." }
+    $testArguments = @("test", $SolutionPath, "--no-restore")
+    Invoke-Dotnet -Arguments $testArguments
 }
 #endregion

--- a/eng/ci/templates/build.yml
+++ b/eng/ci/templates/build.yml
@@ -9,6 +9,9 @@ jobs:
           sbomPackageName: 'Azure Functions PowerShell OpenTelemetry SDK'
           sbomBuildComponentPath: '$(Build.SourcesDirectory)'
     steps:
+      - task: NuGetAuthenticate@1
+        displayName: Authenticate to CFS
+
       - pwsh: ./build.ps1 -Configuration "Release"
         displayName: "Running ./build.ps1 -Configuration 'Release'"
 

--- a/eng/ci/templates/test.yml
+++ b/eng/ci/templates/test.yml
@@ -1,6 +1,9 @@
 jobs:
   - job: UnitTests
     steps:
+      - task: NuGetAuthenticate@1
+        displayName: Authenticate to CFS
+
       - pwsh: ./build.ps1 -Configuration "Release"
         displayName: ./build.ps1 -Configuration "Release"
 


### PR DESCRIPTION
## Summary

- Route every repository-owned NuGet restore through the Azure Functions CFS `upstream-public` feed.
- Make restore source selection explicit and prevent `publish` and `test` from performing implicit downstream restores.
- Authenticate every independent Azure Pipelines job that invokes the restore path.

Owner: @torosent

## Dependency and pipeline audit

- **NuGet/.NET:** Three SDK-style projects and one solution restore through `build.ps1`.
- **Azure Pipelines:** The shared test job is used by public and official Windows/Linux stages; the build job is used by the official artifact stage. Both independent job templates now run `NuGetAuthenticate@1` before the build script.
- **npm/Python/uv:** No repository-owned manifests, install commands, or pipeline restore surfaces.
- **Docker:** No Dockerfiles, compose files, or container restore paths.
- **Release/artifacts:** The official build packages the PowerShell module produced by `build.ps1`; no separate release restore path exists.
- **Helpers:** Existing SDK/SBOM download helpers do not restore npm, NuGet, pip, or uv packages and remain unchanged.
- **Samples/templates:** No customer-facing dependency manifests or scaffolding were changed.

## Changes

- Add root `NuGet.config` with `<clear />`, the CFS NuGet v3 endpoint, and wildcard package source mapping.
- Restore the full solution with `--configfile` via a PowerShell argument array so paths containing spaces remain safe.
- Add `--no-restore` to both project publishes and the solution test command.
- Fail immediately when any `dotnet` command exits nonzero.
- Add `NuGetAuthenticate@1` to the shared build and test job templates.

## Cold-cache proof

Validation used a fresh copy under a path containing spaces with isolated empty global-package, HTTP, plugin, CLI-home, and temp caches. Credential-provider paths and build-token variables were removed for the anonymous proof.

- Full solution restore succeeded anonymously from empty caches.
- 246 observed NuGet network URLs used only `pkgs.dev.azure.com`; no direct nuget.org or MyGet access occurred.
- The restore populated 3,511 cache files.
- `./build.ps1 -Configuration Release` succeeded from a second empty cache set.
- `./build.ps1 -NoBuild -Test` passed all 13 tests.

## Publish and artifact audit

- Audited both `dotnet publish` directories: 223 files total.
- Recreated and inspected the official module ZIP: 23 entries.
- No NuGet/npm/pip configuration, credentials, lockfiles, or `node_modules` appeared in publish output or the packaged module.
- No package versions or lockfiles changed.